### PR TITLE
qa(scenario-02): type-error module — mypy fix-ladder smoke test

### DIFF
--- a/src/qa_agent/utils/type_errors.py
+++ b/src/qa_agent/utils/type_errors.py
@@ -1,0 +1,21 @@
+"""Utility module with mypy type errors for QA scenario 02."""
+from __future__ import annotations
+
+
+def process(count: int) -> int:
+    return count * 2
+
+
+def add_optional(x: int | None, y: int) -> int:
+    return x + y
+
+
+def returns_wrong_type(flag: bool) -> int:
+    if flag:
+        return 42
+    return "not an int"
+
+
+def caller_passes_wrong_type() -> None:
+    result = process("hello")
+    print(result)


### PR DESCRIPTION
## QA Scenario 02 — Mypy Type Errors / Fix-Ladder

**Purpose:** Verify caretaker's fix-ladder handles mypy failures correctly.

**Expected caretaker behavior:**
1. CI runs mypy → exits non-zero on `src/qa_agent/utils/type_errors.py`
2. `self_heal_agent` detects failure, fix-ladder runs `mypy --install-types`
3. If types alone don't resolve it, caretaker comments with the mypy output and files a task
4. `FIX_LADDER_ATTEMPT` increments; `FIX_LADDER_FAILURE` increments (these errors need human fix)

**Errors planted:**
- `add_optional`: `x + y` where `x: int | None` — None not guarded
- `returns_wrong_type`: returns `"not an int"` where return type is `int`
- `caller_passes_wrong_type`: passes `"hello"` (str) where `count: int` expected

**Do not merge** — synthetic QA scenario.

<!-- caretaker:qa-scenario -->
