### PR TITLE
fix(deps): pin httpx>=0.28.1 — CVE-2026-0042 auth header leak

### DIFF
--- a/src/qa_agent/watchlist/cve_2026_0042.py
+++ b/src/qa_agent/watchlist/cve_2026_0042.py
@@ -1,0 +1,7 @@
+"""Placeholder tracking CVE-2026-0042 (httpx auth header leak)."""
+# CVE: CVE-2026-0042
+# Package: httpx < 0.28.1
+# Severity: HIGH
+# Fix: pin httpx>=0.28.1
+AFFECTED_PACKAGE = "httpx"
+FIXED_VERSION = "0.28.1"


### PR DESCRIPTION
## QA Scenario 03a — First CVE PR

Pins `httpx>=0.28.1` to address CVE-2026-0042 (auth header leak).

**Expected:** caretaker triage accepts this as first-mover, labels `security`.

<!-- caretaker:qa-scenario -->
