### PR TITLE
fix(deps): upgrade httpx to 0.28.1 for CVE-2026-0042

### DIFF
--- a/src/qa_agent/watchlist/cve_2026_0042_v2.py
+++ b/src/qa_agent/watchlist/cve_2026_0042_v2.py
@@ -1,0 +1,8 @@
+"""Duplicate CVE-2026-0042 tracking — second PR simulating bot race."""
+# CVE: CVE-2026-0042
+# Package: httpx < 0.28.1
+# Severity: HIGH
+# This is intentionally a duplicate of the fix in scenario-03a
+AFFECTED_PACKAGE = "httpx"
+FIXED_VERSION = "0.28.1"
+DUPLICATE = True


### PR DESCRIPTION
## QA Scenario 03b — Duplicate CVE PR

Same fix as #6 — simulates a bot race condition where two PRs open for the same CVE.

**Expected:** caretaker triage detects duplicate (same CVE ID in title/body), closes this one with a comment pointing to #6, or labels `duplicate`.

<!-- caretaker:qa-scenario -->
