### PR TITLE
refactor(utils): ambiguous generator refactor — shadow readiness test

### DIFF
--- a/src/qa_agent/utils/ambiguous_change.py
+++ b/src/qa_agent/utils/ambiguous_change.py
@@ -1,0 +1,22 @@
+"""Ambiguous utility module for QA scenario 08 — shadow disagreement.
+
+This module makes a change that reasonable reviewers might disagree on:
+changing an explicit list comprehension to a generator expression inside
+a function that expects a list. The change is technically correct but
+could trigger a readiness-gate shadow disagreement.
+"""
+from __future__ import annotations
+
+
+def collect_ids(items: list[dict]) -> list[str]:
+    # Changed from list comp to generator — technically fine since list() wraps it,
+    # but a conservative readiness check might flag this as unready.
+    return list(id_val for item in items if (id_val := item.get("id")))
+
+
+def is_ready_to_merge(pr_title: str, checks_passing: bool) -> bool:
+    # Ambiguous heuristic: title starts with "wip" → not ready
+    # Shadow readiness agent may disagree on what "wip" prefix means
+    if pr_title.lower().startswith("wip"):
+        return False
+    return checks_passing


### PR DESCRIPTION
## QA Scenario 08 — Shadow Disagreement

Tests the `@shadow_decision` agentic layer (`readiness.mode: shadow`).

This PR makes an ambiguous change (list comp → generator expr, new heuristic function) that a conservative readiness check might flag differently than the real gate outcome.

**Expected caretaker behavior:**
1. Real CI gate: passes (code is correct)
2. Shadow readiness agent evaluates the PR: may flag as ambiguous due to the walrus operator + generator in `collect_ids`, or the `wip`-prefix heuristic in `is_ready_to_merge`
3. If shadow disagrees with real outcome → `ShadowDecision` node persisted in memory store
4. `SHADOW_DISAGREEMENT` metric increments
5. Shadow decisions accumulate until enforce-gate flips `shadow → enforce`

**Do not merge** — synthetic QA scenario.

<!-- caretaker:qa-scenario -->
