### PR TITLE
qa(scenario-11): pin ci_log_analysis to azure_ai/claude-sonnet-4 for prompt-cache validation

### DIFF
--- a/.github/maintainer/config.yml
+++ b/.github/maintainer/config.yml
@@ -16,6 +16,14 @@ llm:
   provider: litellm
   claude_enabled: "false"
   default_model: azure_ai/gpt-5.4
+  # QA scenario 11 — pin ci_log_analysis to azure_ai/claude-sonnet-4 to
+  # exercise _supports_prompt_cache (src/caretaker/llm/provider.py:45) and
+  # prove Anthropic prompt caching still works when Claude is routed through
+  # Azure AI Foundry. Reverting: remove this block or set model: null.
+  feature_models:
+    ci_log_analysis:
+      model: azure_ai/claude-sonnet-4
+      max_tokens: 1500
 
 executor:
   provider: auto


### PR DESCRIPTION
## QA Scenario 11 — pin ci_log_analysis to azure_ai/claude-sonnet-4

Pairs with scenario issue #21.

### What this PR does

Adds a single `feature_models.ci_log_analysis` override inside the existing `llm:` block of `.github/maintainer/config.yml`:

```yaml
llm:
  provider: litellm
  claude_enabled: "false"
  default_model: azure_ai/gpt-5.4
  feature_models:          # ← new
    ci_log_analysis:       # ← new
      model: azure_ai/claude-sonnet-4
      max_tokens: 1500
```

### Why

Scenario 11 needs `ci_log_analysis` to route through Azure AI Foundry with a Claude deployment name so we can assert that Anthropic prompt caching still fires through LiteLLM + Azure AI. Specifically this exercises:

- `_supports_prompt_cache(model)` in `src/caretaker/llm/provider.py:45-56` — the substring-on-`"claude"` marker that decides whether to inject `cache_control` content blocks. An `azure_ai/claude-sonnet-4` id clears that check.
- The `caretaker_llm_cache_creation_tokens_total` / `caretaker_llm_cache_read_tokens_total` counters (`src/caretaker/observability/metrics.py:284-296`) with `provider=litellm,model=azure_ai/claude-sonnet-4` labels.
- The LiteLLM code path, not the direct Anthropic SDK path — caretaker-qa has no `ANTHROPIC_API_KEY` and runs with `claude_enabled: "false"`, so any cache-hit metric we see here is unambiguous evidence that the Azure AI Foundry route carried the cache through.

`ci_log_analysis` is already in `CLAUDE_FEATURES` (`src/caretaker/llm/router.py:17-32`) so `feature_enabled("ci_log_analysis")` is True without any additional config.

### Why this one feature

`ci_log_analysis` is the cheapest Claude-routed feature to exercise in a QA repo: small, repeatable prompts (a single CI-failure excerpt) with high prompt-overlap between runs, which is the prompt-cache's best case. The scenario 11 issue body carries a deterministic ~800-token CI-log block that `ci_log_analysis` will re-ingest on every scheduled run — first run mints the cache, subsequent runs should hit it.

### Blast radius / reversibility

One-line config change. No code impact. No other feature is re-routed.

To revert: remove the `feature_models:` block (or set `feature_models.ci_log_analysis.model: null`) and `ci_log_analysis` falls back to `default_model` (`azure_ai/gpt-5.4`).

### Follow-up

Once the memory-snapshot artifact upload bug is fixed (the `include-hidden-files` dotfile issue surfaced during QA review), the cache-token counters will actually flow out of caretaker-qa into downloadable snapshots and the scenario becomes self-verifying via `gh run download` instead of log-scraping.

Closes: none. Tracked by: #21.
