### PR TITLE
ci: install Claude Code workflow (unblocks v0.24.0 hand-off review QA)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,62 @@
+name: Claude Code
+
+# Listens for ``@claude`` mentions and the ``claude-code`` label that
+# caretaker (running in this repo via ``maintainer.yml``) dispatches
+# when its PR-reviewer routes a complex PR to the ``claude_code``
+# hand-off backend. v0.24.0 added a structured-payload contract
+# (``<!-- caretaker:review-result -->`` + fenced ``caretaker-review``
+# JSON block) so caretaker can re-post the review under the GitHub
+# Reviews tab — this workflow is the upstream side of that contract.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [labeled]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'claude-code')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          # caretaker-qa uses ANTHROPIC_API_KEY directly rather than the
+          # OAuth-token path the parent caretaker repo uses. Either is
+          # accepted by the action; use whichever this repo has
+          # configured under Settings → Secrets.
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # Allow the caretaker bot to trigger this workflow via @claude
+          # mentions. Without this, comments posted by the maintainer
+          # workflow (running as github-actions[bot]) are filtered out
+          # and Claude never sees the hand-off.
+          allowed_bots: 'github-actions'
+
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
## Summary

Adds [`.github/workflows/claude.yml`](.github/workflows/claude.yml) so the upstream `anthropics/claude-code-action@v1` listens for `@claude` mentions on this repo. Without it, caretaker's hand-off invitation (posted automatically when a PR routes to the `claude_code` backend, see [#61](https://github.com/ianlintner/caretaker-qa/pull/61)) goes to a workflow that doesn't exist — the cycle never completes.

## Why now

Discovered this gap while running [QA scenario 12](docs/qa-scenarios/12-handoff-review-harvest.md). caretaker correctly dispatched the v0.24.0 hand-off invitation on #61 (with the new structured-payload schema), labeled the PR `claude-code`, and waited for an upstream reply that would never come. This PR closes the gap.

## Configuration

- **Auth:** uses this repo's existing `ANTHROPIC_API_KEY` secret rather than the OAuth-token path the parent `caretaker` repo uses. Either input is accepted by the action.
- **`allowed_bots: github-actions`:** required so the action trusts hand-off comments posted by caretaker's maintainer run (which runs as `github-actions[bot]`). Without it, mentions get filtered out as bot-authored and Claude never replies.

## Verification

After merge, re-trigger the maintainer cron once (`gh workflow run maintainer.yml`) so caretaker re-fires the hand-off (or wait for the next 5-min tick). Then watch [#61](https://github.com/ianlintner/caretaker-qa/pull/61):

```bash
# Should appear within ~3 min:
gh api /repos/ianlintner/caretaker-qa/issues/61/comments \
  --jq '.[] | select(.user.login == "claude") | .body' | head -50

# Should appear in the Reviews tab on the next caretaker cycle (≤5 min after):
gh api /repos/ianlintner/caretaker-qa/pulls/61/reviews \
  --jq '.[] | {user: .user.login, state}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)