### PR TITLE
docs: add QA scenarios convention index [qa-scenario-16]

### DIFF
--- a/docs/qa-scenarios.md
+++ b/docs/qa-scenarios.md
@@ -1,0 +1,34 @@
+# QA Scenarios
+
+This file is a lightweight index of the `qa(scenario-NN: <slug>)` issues
+filed against caretaker-qa to exercise specific caretaker behaviors.
+
+The authoritative list lives as GitHub issues with the
+`<!-- caretaker:qa-scenario -->` HTML-comment marker. Use:
+
+```bash
+gh issue list --repo ianlintner/caretaker-qa \
+  --search '"<!-- caretaker:qa-scenario -->"' --state all --limit 50
+```
+
+to enumerate them. This file exists so a new contributor browsing the
+repo can find the convention without first knowing the marker grep.
+
+## Convention
+
+| Slot | Format | Example |
+|------|--------|---------|
+| Issue title | `qa(scenario-NN): <one-line title>` | `qa(scenario-16): PR flow through event-bus dispatch` |
+| Body marker | `<!-- caretaker:qa-scenario -->` | (machine-readable grep key) |
+| Slug marker | `<!-- scenario-NN: <slug> -->` | `<!-- scenario-16: pr-flow-event-bus -->` |
+| Branch (when a PR is needed) | `caretaker/qa-scenario-NN-<slug>` | `caretaker/qa-scenario-16-pr-flow-event-bus` |
+| Closing label | `caretaker:qa-passed` | (set when the cycle records the scenario as passed) |
+
+The `caretaker/*` head-ref convention is what enables caretaker's
+auto-approval policy on QA-author PRs.
+
+## Cycle skill
+
+The full QA cycle is documented in
+[`.github/skills/caretaker-qa-cycle.md`](https://github.com/ianlintner/caretaker/blob/main/.github/skills/caretaker-qa-cycle.md)
+in the upstream caretaker repo.


### PR DESCRIPTION
Companion PR for [qa-scenario-16](https://github.com/ianlintner/caretaker-qa/issues/65).

Adds `docs/qa-scenarios.md` — a small contributor-facing index of the
`qa(scenario-NN)` issue convention so newcomers can find the marker
grep without first reading the upstream skill. No code changes, no
behavioural impact.

## What this PR is *really* testing

This is the live-fire trigger for QA scenario 16: it exercises the
PR-flow path through the new event-bus dispatch shipped in
[caretaker#621](https://github.com/ianlintner/caretaker/pull/621).
Opening it fires \`pull_request.opened\` to the deployed backend
(`/health` reports `version=0.24.0 dispatch_mode=active`); we expect:

- Status comment lands within ~60s
- `caretaker/pr-readiness` check-run posts conclusion `success | neutral | skipped` (advisory mode never publishes `failure`)
- pr-reviewer / pr-ci-approver / principal agents process via `EVENT_AGENT_MAP[pull_request]` ordering
- Single APPROVE per SHA across replicas (consumer-group at-most-once)

Findings will land in `docs/qa-findings-2026-04-27.md` upstream when the cycle closes.

<!-- caretaker:qa-scenario-16 -->