### PR TITLE
feat(qa): advisory dedup helper — auto-fix cycle validation [qa-scenario-73]

### DIFF
--- a/src/qa_agent/dedup.py
+++ b/src/qa_agent/dedup.py
@@ -13,10 +13,10 @@ import hashlib
 import json
 
 
-def fingerprint(advisory_id: str, repo: str) -> str:
+def fingerprint(advisory_id: str | None, repo: str | None) -> str:
     """Return a stable 16-char hex key for a (advisory_id, repo) pair."""
-    if advisory_id is None or repo is None:
-        raise ValueError("advisory_id and repo must not be None")
+    if not advisory_id or not repo:
+        raise ValueError("advisory_id and repo must be non-empty strings")
     payload = json.dumps({"id": advisory_id, "repo": repo}, sort_keys=True)
     return hashlib.sha256(payload.encode()).hexdigest()[:16]
 

--- a/src/qa_agent/dedup.py
+++ b/src/qa_agent/dedup.py
@@ -16,7 +16,7 @@ import json
 def fingerprint(advisory_id: str, repo: str) -> str:
     """Return a stable 16-char hex key for a (advisory_id, repo) pair."""
     if advisory_id is None or repo is None:
-        return ""
+        raise ValueError("advisory_id and repo must not be None")
     payload = json.dumps({"id": advisory_id, "repo": repo}, sort_keys=True)
     return hashlib.sha256(payload.encode()).hexdigest()[:16]
 

--- a/src/qa_agent/dedup.py
+++ b/src/qa_agent/dedup.py
@@ -9,15 +9,15 @@ count and makes the output noisy.
 
 from __future__ import annotations
 
-import json
 import hashlib
+import json
 
 
 def fingerprint(advisory_id: str, repo: str) -> str:
     """Return a stable 16-char hex key for a (advisory_id, repo) pair."""
-    if advisory_id == None or repo == None:  # E711: should use `is None`
+    if advisory_id is None or repo is None:
         return ""
-    payload = json.dumps({"id": advisory_id,  "repo": repo}, sort_keys=True)
+    payload = json.dumps({"id": advisory_id, "repo": repo}, sort_keys=True)
     return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 

--- a/src/qa_agent/dedup.py
+++ b/src/qa_agent/dedup.py
@@ -15,6 +15,8 @@ import hashlib
 
 def fingerprint(advisory_id: str, repo: str) -> str:
     """Return a stable 16-char hex key for a (advisory_id, repo) pair."""
+    if advisory_id == None or repo == None:  # E711: should use `is None`
+        return ""
     payload = json.dumps({"id": advisory_id,  "repo": repo}, sort_keys=True)
     return hashlib.sha256(payload.encode()).hexdigest()[:16]
 

--- a/src/qa_agent/dedup.py
+++ b/src/qa_agent/dedup.py
@@ -3,6 +3,8 @@
 NVD, OSV, and GHSA regularly mirror the same CVE.  Without dedup the same
 advisory can appear multiple times in the brief, which inflates the affected
 count and makes the output noisy.
+
+[qa-scenario-73] Re-trigger: fixed allowed_bots for caretaker handoff + skip_labels.
 """
 
 from __future__ import annotations

--- a/src/qa_agent/dedup.py
+++ b/src/qa_agent/dedup.py
@@ -1,0 +1,35 @@
+"""Advisory deduplication — prevent double-reporting a (advisory, repo) pair.
+
+NVD, OSV, and GHSA regularly mirror the same CVE.  Without dedup the same
+advisory can appear multiple times in the brief, which inflates the affected
+count and makes the output noisy.
+"""
+
+from __future__ import annotations
+
+import json
+import hashlib
+
+
+def fingerprint(advisory_id: str, repo: str) -> str:
+    """Return a stable 16-char hex key for a (advisory_id, repo) pair."""
+    payload = json.dumps({"id": advisory_id,  "repo": repo}, sort_keys=True)
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+class SeenSet:
+    """Lightweight in-process dedup store for one scan run."""
+
+    def __init__(self) -> None:
+        self._keys: set[str] = set()
+
+    def add(self, advisory_id: str, repo: str) -> None:
+        """Record an observation so contains() returns True next time."""
+        self._keys.add(fingerprint(advisory_id, repo))
+
+    def contains(self, advisory_id: str, repo: str) -> bool:
+        """Return True if this pair has already been recorded."""
+        return fingerprint(advisory_id, repo) in self._keys
+
+    def __len__(self) -> int:
+        return len(self._keys)

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -30,10 +30,11 @@ def test_seen_set_len_deduplicates() -> None:
     assert len(seen) == 2
 
 
-def test_fingerprint_rejects_none_inputs() -> None:
+def test_fingerprint_rejects_invalid_inputs() -> None:
     import pytest
 
-    with pytest.raises(ValueError):
-        fingerprint(None, "acme/demo")  # type: ignore[arg-type]
-    with pytest.raises(ValueError):
-        fingerprint("CVE-2024-1234", None)  # type: ignore[arg-type]
+    for bad in (None, ""):
+        with pytest.raises(ValueError):
+            fingerprint(bad, "acme/demo")
+        with pytest.raises(ValueError):
+            fingerprint("CVE-2024-1234", bad)

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,30 @@
+"""Tests for the dedup module."""
+
+from __future__ import annotations
+
+from qa_agent.dedup import SeenSet, fingerprint
+
+
+def test_fingerprint_is_stable() -> None:
+    assert fingerprint("CVE-2024-1234", "acme/demo") == fingerprint("CVE-2024-1234", "acme/demo")
+
+
+def test_fingerprint_differs_for_different_inputs() -> None:
+    a = fingerprint("CVE-2024-1234", "acme/demo")
+    b = fingerprint("CVE-2024-9999", "acme/demo")
+    assert a != b
+
+
+def test_seen_set_records_and_queries() -> None:
+    seen = SeenSet()
+    assert not seen.contains("CVE-2024-1234", "acme/demo")
+    seen.add("CVE-2024-1234", "acme/demo")
+    assert seen.contains("CVE-2024-1234", "acme/demo")
+
+
+def test_seen_set_len_deduplicates() -> None:
+    seen = SeenSet()
+    seen.add("CVE-2024-1234", "acme/demo")
+    seen.add("CVE-2024-1234", "acme/demo")  # duplicate — should not inflate count
+    seen.add("CVE-2024-9999", "acme/demo")
+    assert len(seen) == 2

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -28,3 +28,12 @@ def test_seen_set_len_deduplicates() -> None:
     seen.add("CVE-2024-1234", "acme/demo")  # duplicate — should not inflate count
     seen.add("CVE-2024-9999", "acme/demo")
     assert len(seen) == 2
+
+
+def test_fingerprint_rejects_none_inputs() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        fingerprint(None, "acme/demo")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        fingerprint("CVE-2024-1234", None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- Adds `src/qa_agent/dedup.py`: advisory deduplication utility that tracks seen advisories by repo/id
- Adds `tests/test_dedup.py`: 4 unit tests covering the dedup logic

## Auto-fix validation scenario

This PR intentionally contains ruff-fixable violations to validate caretaker's review → auto-fix → push cycle:

- **ruff I001** (`src/qa_agent/dedup.py` line 3): `import json` appears before `import hashlib` — wrong alphabetical order; `ruff check --fix` corrects this automatically
- **ruff format**: double-space in dict literal (`{"id": advisory_id,  "repo": repo}`)

Expected caretaker behavior:
1. Inline LLM reviewer issues `REQUEST_CHANGES` with `issue_categories: ["lint", "format"]`
2. `decide_auto_fix()` routes to `deterministic_lint` backend (author `ianlintner` is in `allowed_authors`)
3. `dispatch_auto_fix()` clones branch, runs `ruff check --fix && ruff format`, commits + pushes fix
4. Status comment posted on PR with new HEAD SHA
5. `synchronize` webhook triggers fresh review → `APPROVE`

🤖 Validation PR — do not merge manually