### PR TITLE
chore: route complex/fall-through PR reviews to opencode_local

### DIFF
--- a/.github/maintainer/config.yml
+++ b/.github/maintainer/config.yml
@@ -93,6 +93,21 @@ pr_reviewer:
   # the caretaker:reviewed label (applied after each review) would block the
   # fresh review that validates the fix — breaking the review→auto-fix loop.
   skip_labels: []
+  # Route complex / fall-through reviews to the in-pod opencode_local
+  # backend (caretaker MCP pod has the opencode CLI + OPENROUTER_API_KEY
+  # baked in). The legacy default 'opencode' is a comment-trigger that
+  # requires the sst/opencode-github-action App to be installed in this
+  # repo — it isn't — so handoffs would otherwise sit forever.
+  complex_reviewer: opencode_local
+  # opencode_local must be in the enabled list for non-caretaker-owned
+  # PRs to use it; without this the agent falls back to the first
+  # backend in this list. (caretaker-owned PRs always allow it via
+  # caretaker_owned_reviewer.)
+  enabled_backends:
+    - claude_code
+    - opencode
+    - opencode_local
+    - pr_agent
 
 # Auto-approve workflow runs from trusted bot actors that are gated by
 # GitHub's first-time-contributor owner-approval gate. Without this,


### PR DESCRIPTION
## Why

Discovered while validating v0.28.0 on PR #105: the default \`pr_reviewer.complex_reviewer = "opencode"\` is the **legacy comment-trigger** backend, which requires \`sst/opencode-github-action\` installed in the consumer repo to respond. That App is not installed in caretaker-qa, so any review that falls through to handoff (either via routing or via inline-LLM error) ends up as a permanently-unanswered \`@opencode-agent\` comment.

## Fix

- \`pr_reviewer.complex_reviewer\` → \`opencode_local\` (in-pod CLI run by the caretaker backend)
- \`pr_reviewer.enabled_backends\` → adds \`opencode_local\` so non-caretaker-owned PRs are routed to it

## Why this works for caretaker-qa

The caretaker MCP pod already has:
- \`opencode\` CLI installed (Dockerfile.mcp v0.28.0)
- \`OPENROUTER_API_KEY\` in the pod env (from caretaker-secrets in AKV)
- A 4Gi \`/tmp/caretaker-pr-review\` emptyDir for clones

So \`opencode_local\` runs synchronously in the pod, posts the review directly via the GitHub Reviews API, and the auto-fix loop can chain off it. No external Action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)